### PR TITLE
[Enhancement] New flag to exclude tactic from filename of the custom rules toml files

### DIFF
--- a/CLI.md
+++ b/CLI.md
@@ -520,6 +520,7 @@ Options:
   -e, --export-exceptions         Include exceptions in export
   -s, --skip-errors               Skip errors when exporting rules
   -sv, --strip-version            Strip the version fields from all rules
+  -nt, --no-tactic-filename       Exclude tactic prefix in exported filenames for rules
   -h, --help                      Show this message and exit.
 
 ```

--- a/detection_rules/kbwrap.py
+++ b/detection_rules/kbwrap.py
@@ -182,7 +182,7 @@ def kibana_import_rules(ctx: click.Context, rules: RuleCollection, overwrite: Op
 @click.option("--export-exceptions", "-e", is_flag=True, help="Include exceptions in export")
 @click.option("--skip-errors", "-s", is_flag=True, help="Skip errors when exporting rules")
 @click.option("--strip-version", "-sv", is_flag=True, help="Strip the version fields from all rules")
-@click.option("--no-tactic-filename", is_flag=True, help="Exclude tactic prefix in exported filenames")
+@click.option("--no-tactic-filename", "-nt", is_flag=True, help="Exclude tactic prefix in exported filenames for rules")
 @click.pass_context
 def kibana_export_rules(ctx: click.Context, directory: Path, action_connectors_directory: Optional[Path],
                         exceptions_directory: Optional[Path], default_author: str,

--- a/detection_rules/kbwrap.py
+++ b/detection_rules/kbwrap.py
@@ -182,11 +182,13 @@ def kibana_import_rules(ctx: click.Context, rules: RuleCollection, overwrite: Op
 @click.option("--export-exceptions", "-e", is_flag=True, help="Include exceptions in export")
 @click.option("--skip-errors", "-s", is_flag=True, help="Skip errors when exporting rules")
 @click.option("--strip-version", "-sv", is_flag=True, help="Strip the version fields from all rules")
+@click.option("--no-tactic-filename", is_flag=True, help="Exclude tactic prefix in exported filenames")
 @click.pass_context
 def kibana_export_rules(ctx: click.Context, directory: Path, action_connectors_directory: Optional[Path],
                         exceptions_directory: Optional[Path], default_author: str,
                         rule_id: Optional[Iterable[str]] = None, export_action_connectors: bool = False,
-                        export_exceptions: bool = False, skip_errors: bool = False, strip_version: bool = False
+                        export_exceptions: bool = False, skip_errors: bool = False, strip_version: bool = False,
+                        no_tactic_filename: bool = False
                         ) -> List[TOMLRule]:
     """Export custom rules from Kibana."""
     kibana = ctx.obj["kibana"]
@@ -246,7 +248,9 @@ def kibana_export_rules(ctx: click.Context, directory: Path, action_connectors_d
             maturity = "development"
             threat = rule_resource.get("threat")
             first_tactic = threat[0].get("tactic").get("name") if threat else ""
-            rule_name = rulename_to_filename(rule_resource.get("name"), tactic_name=first_tactic)
+            # Check if the flag is set to not include tactic in the filename
+            tactic_name = first_tactic if not no_tactic_filename else None
+            rule_name = rulename_to_filename(rule_resource.get("name"), tactic_name=tactic_name)
             # check if directory / f"{rule_name}" exists
             if (directory / f"{rule_name}").exists():
                 rules = RuleCollection()


### PR DESCRIPTION
<!--
Thank you for your interest in and contributing to Detection Rules!
There are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your attention.
-->
# Pull Request



<!--
  Add Related Issues / PRs for context. Eg:
    Related to elastic/repo#999
    Resolves #123
  If there is no issue link, take extra care to write a clear summary and label the PR just as you would label an issue to give additional context to reviewers.
-->

## Summary - What I changed

<!--
  Summarize your PR. Animated gifs are 💯. Code snippets are ⚡️. Examples & screenshots are 🔥
-->

1. You use the repository for DaC and have a custom rule folder for your company rules
2. You export rules from kibana to the folder via the repos CLI
3. The name of the toml files for the rules are all prefixed with the tactic name but you dont want this since you have a clear naming convention for all your rules and the toml file name should be just the rule name (no tactic prefix)
4. So I added this new flag: "--no-tactic-filename"
5. With this the toml files are simply named like the rule name, nice!

The adjustment was straightforward, check the code diff :)

## How To Test

<!--
  Some examples of what you could include here are:
  * Links to GitHub action results for CI test improvements
  * Sample data before/after screenshots (or short videos showing how something works)
  * Copy/pasted commands and output from the testing you did in your local terminal window
  * If tests run in GitHub, you can 🪁or 🔱, respectively, to indicate tests will run in CI
  * Query used in your stack to verify the change
-->

1. Export rules via CLI
```
python -m detection_rules kibana export-rules -d custom-rules
```
2. And now use the new flag
```
python -m detection_rules kibana export-rules -d custom-rules --no-tactic-filename
```
Filenames are just the rule name now :rocket: 


## Checklist

<!-- Delete any items that are not applicable to this PR. -->

- [x] Added a label for the type of pr: `bug`, `enhancement`, `schema`, `maintenance`, `Rule: New`, `Rule: Deprecation`, `Rule: Tuning`, `Hunt: New`, or `Hunt: Tuning` so guidelines can be generated
- [x] Added the `meta:rapid-merge` label if planning to merge within 24 hours
- [x] Secret and sensitive material has been managed correctly
- [x] Automated testing was updated or added to match the most common scenarios
- [x] Documentation and comments were added for features that require explanation

## Contributor checklist

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
- Have you followed the [contributor guidelines](https://github.com/elastic/detection-rules/blob/main/CONTRIBUTING.md)?
