### PR TITLE
Add CLI environment notes in AGENTS

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,45 @@
+# Agent Instructions: Repo Overview and CLI
+
+This repository hosts the Elastic Security detection rules and the supporting command line tooling.
+
+## Repository Structure
+- `detection_rules/` – main Python package containing the CLI and rule management libraries.
+- `lib/` – Python packages that are installed locally (`kibana` and `kql`).
+- `rules/` and `rules_building_block/` – rule definitions in TOML format.
+- `hunting/` – threat hunting queries with its own lightweight CLI.
+- `tests/` – unit tests for the rule loader and CLI utilities.
+
+## CLI Quickstart
+- The CLI entry point is `python -m detection_rules` which runs `detection_rules.__main__:main`.
+- Commands are implemented with the [click](https://click.palletsprojects.com/) framework in `detection_rules/main.py` and related modules.
+- Run `python -m detection_rules --help` to view the available commands. Each subcommand also accepts `--help`.
+
+## Development Notes
+- Install dependencies via `make` or with `pip install .[dev] && pip install lib/kibana lib/kql`.
+- Unit tests run with `python -m detection_rules test` or `make test`.
+- Style is checked with `pre-commit` hooks configured in `.pre-commit-config.yaml`.
+
+### CLI Usage Guidelines
+Focus on building new CLI commands and helpers. Avoid running arbitrary commands
+from the repository. Only invoke:
+
+- `python -m flake8 tests detection_rules --ignore D203,N815 --max-line-length 120` to lint new code.
+- `bandit -r detection_rules -s B101,B603,B404,B607` for a security scan.
+- CLI commands necessary to verify new features, such as running a command you
+just implemented.
+
+The CLI environment is already available. Launch `python -m detection_rules --help`
+to explore commands.
+
+### Using the Test Environment
+The test instance credentials are provided via environment variables:
+`KIBANA_URL`, `ELASTIC_URL`, `USERNAME`, `PASSWORD` and `API_KEY`. Export these
+as `DR_KIBANA_URL`, `DR_ELASTICSEARCH_URL`, `DR_USER`, `DR_PASSWORD` and
+`DR_API_KEY` to allow the CLI to automatically authenticate. Alternatively you
+can create a `.detection-rules-cfg.json` (or `.yaml`) file with the same keys, or
+pass them directly as command arguments. Do **not** commit the config file or
+secrets.
+
+When developing new CLI features, look under `detection_rules/` for the relevant
+command group or utility functions. Additional summaries of subfolders are
+provided in their respective `AGENTS.md` files.

--- a/detection_rules/AGENTS.md
+++ b/detection_rules/AGENTS.md
@@ -1,0 +1,31 @@
+# Agent Instructions: detection_rules package
+
+This directory is the main Python package implementing the CLI.  Key files and their roles are listed below.
+
+## Entry Points
+- `__main__.py` – prints a banner and invokes the CLI. Executed when running `python -m detection_rules`.
+- `main.py` – defines the root `click` group and most top-level commands. Subcommands use decorators `@root.command` or `@root.group`.
+
+## Command Groups
+- `kbwrap.py` – `kibana` command group for interacting with a Kibana instance (import/export rules, manage exceptions, etc.).
+- `eswrap.py` – `es` command group for Elasticsearch operations such as searching and normalizing data.
+- `devtools.py` – `dev` group used internally for building and packaging rules.
+- `custom_rules.py` – manages custom rule lifecycle through the `custom-rules` group.
+- `main.py` also defines the `typosquat` group for typosquatting related utilities.
+
+## Supporting Modules
+- `rule_loader.py`, `rule.py` – parse and validate rule TOML files.
+- `packaging.py`, `navigator.py` – create packages and summary docs for releases.
+- `cli_utils.py`, `misc.py` – shared helpers for prompts, clients and command options.
+- `schemas/` – dataclasses and schema validation for rules and packages.
+- `etc/` – configuration files (ECS schemas, version settings, etc.).
+
+### Auth and Configuration
+Commands that communicate with Kibana or Elasticsearch read authentication
+details from environment variables prefixed with `DR_`. For example export
+`DR_KIBANA_URL`, `DR_ELASTICSEARCH_URL`, `DR_USER`, `DR_PASSWORD` and
+`DR_API_KEY` to match the provided test instance variables. The same options can
+also be stored in `.detection-rules-cfg.json` or passed as command arguments.
+Credentials files should never be committed.
+
+When adding a new CLI subcommand, start in `main.py` to register it with the root group, then implement logic in a dedicated module or an existing one listed above.

--- a/hunting/AGENTS.md
+++ b/hunting/AGENTS.md
@@ -1,0 +1,8 @@
+# Agent Instructions: Hunting queries
+
+The `hunting` directory stores threat hunting queries and includes a lightweight CLI located in `hunting/__main__.py`.
+
+- Each hunt consists of a TOML and Markdown file describing the query and context.
+- Running `python -m hunting` provides commands to generate markdown, execute queries and manage hunt data.
+
+These utilities are separate from the main `detection_rules` CLI but follow a similar click-based structure.

--- a/lib/kibana/AGENTS.md
+++ b/lib/kibana/AGENTS.md
@@ -1,0 +1,9 @@
+# Agent Instructions: Kibana helper library
+
+The `lib/kibana` directory contains a small package used by the CLI for interacting with Kibana APIs.
+
+- `kibana/connector.py` defines the `Kibana` client used in `detection_rules/kbwrap.py`.
+- `kibana/resources.py` contains dataclasses representing Kibana rule resources (`RuleResource`, `Signal`).
+- The package is not published to PyPI; during development it is installed from this directory (`pip install lib/kibana`).
+
+Most CLI commands that talk to Kibana import this package. When modifying the client behavior or API interactions, adjust these files and reinstall the package in your environment.

--- a/lib/kql/AGENTS.md
+++ b/lib/kql/AGENTS.md
@@ -1,0 +1,8 @@
+# Agent Instructions: KQL parsing library
+
+The `lib/kql` directory provides utilities for parsing and converting Kibana Query Language (KQL).
+
+- Core functionality resides in `kql/*.py` (e.g., `parser.py`, `eql2kql.py`, `kql2eql.py`).
+- The package is installed locally via `pip install lib/kql` and used throughout the CLI for query validation and conversion.
+
+If you need to extend query parsing logic or add new converters, explore these modules and reinstall the package after changes.


### PR DESCRIPTION
## Summary
- expand root AGENTS with CLI usage rules and test environment variables
- document DR_ env variable flow in detection_rules instructions

## Testing
- `python -m flake8 tests detection_rules --ignore D203,N815 --max-line-length 120`
- `bandit -r detection_rules -s B101,B603,B404,B607`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'eql')*

------
https://chatgpt.com/codex/tasks/task_e_685bf3a80afc83339841112c86d62436