### PR TITLE
Add multiple --rule-name support for export-rules

### DIFF
--- a/CLI.md
+++ b/CLI.md
@@ -504,7 +504,7 @@ Options:
                                   Directory to export exceptions to
   -da, --default-author TEXT      Default author for rules missing one
   -r, --rule-id TEXT              Optional Rule IDs to restrict export to
-  -rn, --rule-name TEXT           Optional Rule name to restrict export to (KQL, case-insensitive, supports wildcards)
+  -rn, --rule-name TEXT           Optional Rule name to restrict export to (KQL, case-insensitive, supports wildcards). May be specified multiple times.
   -ac, --export-action-connectors
                                   Include action connectors in export
   -e, --export-exceptions         Include exceptions in export

--- a/detection_rules/kbwrap.py
+++ b/detection_rules/kbwrap.py
@@ -214,8 +214,12 @@ def kibana_import_rules(  # noqa: PLR0915
 @click.option(
     "--rule-name",
     "-rn",
+    multiple=True,
     required=False,
-    help="Optional Rule name to restrict export to (KQL, case-insensitive, supports wildcards)",
+    help=(
+        "Optional Rule name to restrict export to (KQL, case-insensitive, supports wildcards). "
+        "May be specified multiple times."
+    ),
 )
 @click.option("--export-action-connectors", "-ac", is_flag=True, help="Include action connectors in export")
 @click.option("--export-exceptions", "-e", is_flag=True, help="Include exceptions in export")
@@ -249,7 +253,7 @@ def kibana_export_rules(  # noqa: PLR0912, PLR0913, PLR0915
     exceptions_directory: Path | None,
     default_author: str,
     rule_id: list[str] | None = None,
-    rule_name: str | None = None,
+    rule_name: list[str] | None = None,
     export_action_connectors: bool = False,
     export_exceptions: bool = False,
     skip_errors: bool = False,
@@ -271,8 +275,11 @@ def kibana_export_rules(  # noqa: PLR0912, PLR0913, PLR0915
     with kibana:
         # Look up rule IDs by name if --rule-name was provided
         if rule_name:
-            found = RuleResource.find(filter=f"alert.attributes.name:{rule_name}")  # type: ignore[reportUnknownMemberType]
-            rule_id = [r["rule_id"] for r in found]  # type: ignore[reportUnknownVariableType]
+            found_ids: list[str] = []
+            for name in rule_name:
+                found = RuleResource.find(filter=f"alert.attributes.name:{name}")  # type: ignore[reportUnknownMemberType]
+                found_ids.extend([r["rule_id"] for r in found])  # type: ignore[reportUnknownVariableType]
+            rule_id = list(dict.fromkeys(found_ids))
         query = (
             export_query
             if not custom_rules_only


### PR DESCRIPTION
## Summary
- allow specifying `--rule-name` multiple times when exporting rules
- update CLI docs for the new behavior

## Testing
- `python -m flake8 tests detection_rules --ignore D203,N815 --max-line-length 120` *(fails: E501 etc.)*
- `bandit -r detection_rules -s B101,B603,B404,B607`

------
https://chatgpt.com/codex/tasks/task_e_686b896806fc8333abad7d539579b01e