### PR TITLE
Add option to strip exception list ids

### DIFF
--- a/CLI.md
+++ b/CLI.md
@@ -102,6 +102,8 @@ Options:
   -ske, --skip-errors             Skip rule import errors
   -da, --default-author TEXT      Default author for rules missing one
   -snv, --strip-none-values       Strip None values from the rule
+  -seli, --strip-exception-list-id
+                                  Omit 'id' from exceptions_list entries
   -lc, --local-creation-date      Preserve the local creation date of the rule
   -lu, --local-updated-date       Preserve the local updated date of the rule
   -h, --help                      Show this message and exit.
@@ -510,6 +512,8 @@ Options:
   -e, --export-exceptions         Include exceptions in export
   -s, --skip-errors               Skip errors when exporting rules
   -sv, --strip-version            Strip the version fields from all rules
+  -seli, --strip-exception-list-id
+                                  Omit 'id' from exceptions_list entries
   -nt, --no-tactic-filename       Exclude tactic prefix in exported filenames for rules. Use same flag for import-rules to prevent warnings and disable its unit test.
   -lc, --local-creation-date      Preserve the local creation date of the rule
   -lu, --local-updated-date       Preserve the local updated date of the rule

--- a/detection_rules/cli_utils.py
+++ b/detection_rules/cli_utils.py
@@ -141,6 +141,7 @@ def rule_prompt(  # noqa: PLR0912, PLR0913, PLR0915
     additional_required: list[str] | None = None,
     skip_errors: bool = False,
     strip_none_values: bool = True,
+    strip_exception_list_id: bool = RULES_CONFIG.strip_exception_list_id,
     **kwargs: Any,
 ) -> TOMLRule | str:
     """Prompt loop to build a rule."""
@@ -294,7 +295,7 @@ def rule_prompt(  # noqa: PLR0912, PLR0913, PLR0915
         raise
 
     if save:
-        rule.save_toml(strip_none_values=strip_none_values)
+        rule.save_toml(strip_none_values=strip_none_values, strip_exception_list_id=strip_exception_list_id)
 
     if skipped:
         print("Did not set the following values because they are un-required when set to the default value")

--- a/detection_rules/config.py
+++ b/detection_rules/config.py
@@ -209,6 +209,7 @@ class RulesConfig:
     normalize_kql_keywords: bool = True
     bypass_optional_elastic_validation: bool = False
     no_tactic_filename: bool = False
+    strip_exception_list_id: bool = False
 
     def __post_init__(self) -> None:
         """Perform post validation on packages.yaml file."""
@@ -327,6 +328,8 @@ def parse_rules_config(path: Path | None = None) -> RulesConfig:  # noqa: PLR091
 
     # no_tactic_filename
     contents["no_tactic_filename"] = loaded.get("no_tactic_filename", False)
+
+    contents["strip_exception_list_id"] = loaded.get("strip_exception_list_id", False)
 
     # return the config
     try:

--- a/detection_rules/etc/_config.yaml
+++ b/detection_rules/etc/_config.yaml
@@ -75,5 +75,8 @@ normalize_kql_keywords: False
 
 # To prevent the tactic prefix from being added to the rule filename, set the line below to True
 # This config line can be used instead of specifying the `--no-tactic-filename` flag in the CLI
-# Mind that for unit tests, you also want to disable the filename test in the test_config.yaml
-# no_tactic_filename: True
+# Mind that for unit tests, you also want to disable the filename test in the test_config.yaml# no_tactic_filename: True
+
+# To exclude the `id` value from exception list entries when saving rules, set the line below to True
+# This mirrors the `--strip-exception-list-id` CLI flag
+# strip_exception_list_id: True

--- a/detection_rules/kbwrap.py
+++ b/detection_rules/kbwrap.py
@@ -221,6 +221,7 @@ def kibana_import_rules(  # noqa: PLR0915
 @click.option("--export-exceptions", "-e", is_flag=True, help="Include exceptions in export")
 @click.option("--skip-errors", "-s", is_flag=True, help="Skip errors when exporting rules")
 @click.option("--strip-version", "-sv", is_flag=True, help="Strip the version fields from all rules")
+@click.option("--strip-exception-list-id", "-seli", is_flag=True, help="Omit 'id' from exceptions_list entries")
 @click.option(
     "--no-tactic-filename",
     "-nt",
@@ -254,6 +255,7 @@ def kibana_export_rules(  # noqa: PLR0912, PLR0913, PLR0915
     export_exceptions: bool = False,
     skip_errors: bool = False,
     strip_version: bool = False,
+    strip_exception_list_id: bool = False,
     no_tactic_filename: bool = False,
     local_creation_date: bool = False,
     local_updated_date: bool = False,
@@ -424,7 +426,7 @@ def kibana_export_rules(  # noqa: PLR0912, PLR0913, PLR0915
     saved: list[TOMLRule] = []
     for rule in exported:
         try:
-            rule.save_toml()
+            rule.save_toml(strip_exception_list_id=strip_exception_list_id)
         except Exception as e:
             if skip_errors:
                 print(f"- skipping {rule.contents.data.name} - {type(e).__name__}")

--- a/detection_rules/main.py
+++ b/detection_rules/main.py
@@ -155,6 +155,7 @@ def generate_rules_index(
 @click.option("--skip-errors", "-ske", is_flag=True, help="Skip rule import errors")
 @click.option("--default-author", "-da", type=str, required=False, help="Default author for rules missing one")
 @click.option("--strip-none-values", "-snv", is_flag=True, help="Strip None values from the rule")
+@click.option("--strip-exception-list-id", "-seli", is_flag=True, help="Omit 'id' from exceptions_list entries")
 @click.option("--local-creation-date", "-lc", is_flag=True, help="Preserve the local creation date of the rule")
 @click.option("--local-updated-date", "-lu", is_flag=True, help="Preserve the local updated date of the rule")
 def import_rules_into_repo(  # noqa: PLR0912, PLR0913, PLR0915
@@ -169,6 +170,7 @@ def import_rules_into_repo(  # noqa: PLR0912, PLR0913, PLR0915
     skip_errors: bool,
     default_author: str,
     strip_none_values: bool,
+    strip_exception_list_id: bool,
     local_creation_date: bool,
     local_updated_date: bool,
 ) -> None:
@@ -238,6 +240,7 @@ def import_rules_into_repo(  # noqa: PLR0912, PLR0913, PLR0915
             additional_required=additional,
             skip_errors=skip_errors,
             strip_none_values=strip_none_values,
+            strip_exception_list_id=strip_exception_list_id,
             **contents,
         )
         # If output is not a TOMLRule

--- a/detection_rules/rule.py
+++ b/detection_rules/rule.py
@@ -1585,7 +1585,11 @@ class TOMLRule:
                 return rule_path.relative_to(rules_dir)
         return None
 
-    def save_toml(self, strip_none_values: bool = True) -> None:
+    def save_toml(
+        self,
+        strip_none_values: bool = True,
+        strip_exception_list_id: bool | None = None,
+    ) -> None:
         if self.path is None:
             raise ValueError(f"Can't save rule {self.name} (self.id) without a path")
 
@@ -1595,6 +1599,16 @@ class TOMLRule:
         }
         if self.contents.transform:
             converted["transform"] = self.contents.transform.to_dict()
+
+        if strip_exception_list_id is None:
+            from .config import RULES_CONFIG
+
+            strip_exception_list_id = RULES_CONFIG.strip_exception_list_id
+        if strip_exception_list_id:
+            exceptions = converted["rule"].get("exceptions_list")
+            if exceptions:
+                for exc in exceptions:
+                    exc.pop("id", None)
 
         if not self.path:
             raise ValueError("No path found")

--- a/tests/test_exception_id.py
+++ b/tests/test_exception_id.py
@@ -1,0 +1,40 @@
+from pathlib import Path
+
+import pytoml
+
+from detection_rules.rule import TOMLRule, TOMLRuleContents
+
+
+def make_test_rule(tmp_path: Path) -> TOMLRule:
+    data = {
+        "metadata": {
+            "creation_date": "2024/01/01",
+            "updated_date": "2024/01/01",
+            "maturity": "development",
+        },
+        "rule": {
+            "author": ["Elastic"],
+            "description": "test",
+            "rule_id": "00000000-0000-0000-0000-000000000000",
+            "risk_score": 21,
+            "severity": "low",
+            "type": "query",
+            "language": "kuery",
+            "query": "process.name: test",
+            "name": "Test Rule",
+            "exceptions_list": [
+                {"id": "abc", "list_id": "abc", "namespace_type": "single", "type": "detection"}
+            ],
+        },
+    }
+    contents = TOMLRuleContents.from_dict(data)
+    path = tmp_path / "rule.toml"
+    return TOMLRule(contents=contents, path=path)
+
+
+def test_strip_exception_id(tmp_path: Path):
+    rule = make_test_rule(tmp_path)
+    rule.save_toml(strip_exception_list_id=True)
+    loaded = pytoml.load((tmp_path / "rule.toml").open())
+    exc = loaded["rule"]["exceptions_list"][0]
+    assert "id" not in exc


### PR DESCRIPTION
## Summary
- add `strip_exception_list_id` config option
- support `--strip-exception-list-id` flag in rule import/export
- allow `TOMLRule.save_toml` to drop exception list ids
- document new flag in CLI docs and config
- test stripping exception list ids

## Testing
- `python -m ruff check detection_rules/cli_utils.py detection_rules/main.py detection_rules/rule.py detection_rules/config.py tests/test_exception_id.py`
- `python -m pytest tests/test_exception_id.py -q`

------
https://chatgpt.com/codex/tasks/task_e_686e4b4a32a88333b4271efc4abc0c0f