### PR TITLE
Add strip_version config support

### DIFF
--- a/detection_rules/config.py
+++ b/detection_rules/config.py
@@ -209,6 +209,7 @@ class RulesConfig:
     normalize_kql_keywords: bool = True
     bypass_optional_elastic_validation: bool = False
     no_tactic_filename: bool = False
+    strip_version: bool = False
 
     def __post_init__(self) -> None:
         """Perform post validation on packages.yaml file."""
@@ -327,6 +328,9 @@ def parse_rules_config(path: Path | None = None) -> RulesConfig:  # noqa: PLR091
 
     # no_tactic_filename
     contents["no_tactic_filename"] = loaded.get("no_tactic_filename", False)
+
+    # strip_version
+    contents["strip_version"] = loaded.get("strip_version", False)
 
     # return the config
     try:

--- a/detection_rules/etc/_config.yaml
+++ b/detection_rules/etc/_config.yaml
@@ -77,3 +77,7 @@ normalize_kql_keywords: False
 # This config line can be used instead of specifying the `--no-tactic-filename` flag in the CLI
 # Mind that for unit tests, you also want to disable the filename test in the test_config.yaml
 # no_tactic_filename: True
+
+# To omit version fields from exported rules, set the line below to True
+# This config line can be used instead of specifying the `--strip-version` flag in the CLI
+# strip_version: True

--- a/detection_rules/kbwrap.py
+++ b/detection_rules/kbwrap.py
@@ -275,6 +275,7 @@ def kibana_export_rules(  # noqa: PLR0912, PLR0913, PLR0915
 ) -> list[TOMLRule]:
     """Export custom rules from Kibana."""
     kibana = ctx.obj["kibana"]
+    strip_version = strip_version or RULES_CONFIG.strip_version
     kibana_include_details = export_exceptions or export_action_connectors
 
     # Only allow one of rule_id or rule_name

--- a/docs-dev/custom-rules-management.md
+++ b/docs-dev/custom-rules-management.md
@@ -77,6 +77,8 @@ Some notes:
 * To turn on automatic schema generation for non-ecs fields via custom schemas add `auto_gen_schema_file: <path_to_your_json_file>`. This will generate a schema file in the specified location that will be used to add entries for each field and index combination that is not already in a known schema. This will also automatically add it to your stack-schema-map.yaml file when using a custom rules directory and config.
 * For Kibana action items, currently these are included in the rule toml files themselves. At a later date, we may allow for bulk editing of rule action items through separate action toml files. The action_dir config key is left available for this later implementation. For now to bulk update, use the bulk actions add rule actions UI in Kibana.
 * To on bulk disable elastic validation for optional fields, use the following line `bypass_optional_elastic_validation: True`.
+* To omit version fields when exporting rules, set `strip_version: True` or use the `--strip-version` flag. This only strips the
+  `version` and `revision` fields from exported rule TOML files and does not impact the version lock strategy.
 
 
 When using the repo, set the environment variable `CUSTOM_RULES_DIR=<directory-with-_config.yaml>`
@@ -139,6 +141,13 @@ RULES_CONFIG.stack_schema_map
 
 ### Version Strategy Warning
 
+- `bypass_version_lock` determines whether rule versions are managed through the
+  version lock file. When set to `True`, versions from Kibana or rule TOML files
+  are respected and the lock file is ignored. When `False` (default) version and
+  revision fields from Kibana or the TOML are skipped, and the lock file
+  controls versioning.
+- Note that `strip_version` simply removes the `version` and `revision` fields from
+exported rules and does not change this version lock behaviour.
 - General (`bypass_version_lock = False`)
   - Default
   - Versions from Kibana or the TOML file are ignored

--- a/docs-logs/2025-07-strip_version-config.md
+++ b/docs-logs/2025-07-strip_version-config.md
@@ -1,0 +1,3 @@
+## Add strip_version config support
+
+Implemented reading `strip_version` from `_config.yaml` and applying it during rule export. The option mirrors `--strip-version` on the CLI and removes `version` and `revision` fields from exported rules. Documentation was updated and the option can also be used via the CLI flag or configuration file.

--- a/rules-test/_config.yaml
+++ b/rules-test/_config.yaml
@@ -18,3 +18,6 @@ auto_gen_schema_file: etc/schema.json
 bypass_optional_elastic_validation: True
 # We dont prefix the filenames with the tactic name
 no_tactic_filename: True
+
+# Example config to strip version fields during export
+# strip_version: True


### PR DESCRIPTION
## Summary
- support `strip_version` in `_config.yaml`
- document `strip_version` option in CLI docs and examples
- enable config handling for `--strip-version`

## Testing
- `python -m ruff check --exit-non-zero-on-fix`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'kibana')*

------
https://chatgpt.com/codex/tasks/task_e_6874cb34451c83339b092972bdfcef24