### PR TITLE
Fix optional metadata date validation

### DIFF
--- a/CLI.md
+++ b/CLI.md
@@ -104,6 +104,7 @@ Options:
   -ske, --skip-errors             Skip rule import errors
   -da, --default-author TEXT      Default author for rules missing one
   -snv, --strip-none-values       Strip None values from the rule
+  -sd, --strip-dates              Strip creation and updated date fields from imported rules
   -lc, --local-creation-date      Preserve the local creation date of the rule
   -lu, --local-updated-date       Preserve the local updated date of the rule
   -h, --help                      Show this message and exit.

--- a/CLI.md
+++ b/CLI.md
@@ -512,6 +512,7 @@ Options:
   -e, --export-exceptions         Include exceptions in export
   -s, --skip-errors               Skip errors when exporting rules
   -sv, --strip-version            Strip the version fields from all rules
+  -sd, --strip-dates              Strip creation and updated date fields from exported rules
   -nt, --no-tactic-filename       Exclude tactic prefix in exported filenames for rules. Use same flag for import-rules to prevent warnings and disable its unit test.
   -lc, --local-creation-date      Preserve the local creation date of the rule
   -lu, --local-updated-date       Preserve the local updated date of the rule

--- a/detection_rules/cli_utils.py
+++ b/detection_rules/cli_utils.py
@@ -141,6 +141,7 @@ def rule_prompt(  # noqa: PLR0912, PLR0913, PLR0915
     additional_required: list[str] | None = None,
     skip_errors: bool = False,
     strip_none_values: bool = True,
+    strip_dates: bool = False,
     **kwargs: Any,
 ) -> TOMLRule | str:
     """Prompt loop to build a rule."""
@@ -249,11 +250,13 @@ def rule_prompt(  # noqa: PLR0912, PLR0913, PLR0915
     suggested_path: Path = Path(DEFAULT_PREBUILT_RULES_DIRS[0]) / contents["name"]
     path = Path(path or input(f"File path for rule [{suggested_path}]: ") or suggested_path).resolve()
     # Inherit maturity and optionally local dates from the rule if it already exists
-    meta = {
-        "creation_date": kwargs.get("creation_date") or creation_date,
-        "updated_date": kwargs.get("updated_date") or creation_date,
-        "maturity": "development",
-    }
+    if strip_dates:
+        kwargs.pop("creation_date", None)
+        kwargs.pop("updated_date", None)
+    meta = {"maturity": "development"}
+    if not strip_dates:
+        meta["creation_date"] = kwargs.get("creation_date") or creation_date
+        meta["updated_date"] = kwargs.get("updated_date") or creation_date
 
     try:
         rule_contents = TOMLRuleContents.from_dict({"rule": contents, "metadata": meta})

--- a/detection_rules/config.py
+++ b/detection_rules/config.py
@@ -210,6 +210,7 @@ class RulesConfig:
     bypass_optional_elastic_validation: bool = False
     no_tactic_filename: bool = False
     strip_version: bool = False
+    strip_dates: bool = False
 
     def __post_init__(self) -> None:
         """Perform post validation on packages.yaml file."""
@@ -331,6 +332,9 @@ def parse_rules_config(path: Path | None = None) -> RulesConfig:  # noqa: PLR091
 
     # strip_version
     contents["strip_version"] = loaded.get("strip_version", False)
+
+    # strip_dates
+    contents["strip_dates"] = loaded.get("strip_dates", False)
 
     # return the config
     try:

--- a/detection_rules/etc/_config.yaml
+++ b/detection_rules/etc/_config.yaml
@@ -81,3 +81,6 @@ normalize_kql_keywords: False
 # To omit version fields from exported rules, set the line below to True
 # This config line can be used instead of specifying the `--strip-version` flag in the CLI
 # strip_version: True
+
+# Strip creation_date and updated_date fields when exporting rules
+# strip_dates: True

--- a/detection_rules/kbwrap.py
+++ b/detection_rules/kbwrap.py
@@ -234,6 +234,7 @@ def kibana_import_rules(  # noqa: PLR0915
 @click.option("--export-exceptions", "-e", is_flag=True, help="Include exceptions in export")
 @click.option("--skip-errors", "-s", is_flag=True, help="Skip errors when exporting rules")
 @click.option("--strip-version", "-sv", is_flag=True, help="Strip the version fields from all rules")
+@click.option("--strip-dates", "-sd", is_flag=True, help="Strip creation and updated date fields from exported rules")
 @click.option(
     "--no-tactic-filename",
     "-nt",
@@ -267,6 +268,7 @@ def kibana_export_rules(  # noqa: PLR0912, PLR0913, PLR0915
     export_exceptions: bool = False,
     skip_errors: bool = False,
     strip_version: bool = False,
+    strip_dates: bool = False,
     no_tactic_filename: bool = False,
     local_creation_date: bool = False,
     local_updated_date: bool = False,
@@ -441,7 +443,7 @@ def kibana_export_rules(  # noqa: PLR0912, PLR0913, PLR0915
     saved: list[TOMLRule] = []
     for rule in exported:
         try:
-            rule.save_toml()
+            rule.save_toml(strip_dates=strip_dates or RULES_CONFIG.strip_dates)
         except Exception as e:
             if skip_errors:
                 print(f"- skipping {rule.contents.data.name} - {type(e).__name__}")

--- a/detection_rules/kbwrap.py
+++ b/detection_rules/kbwrap.py
@@ -374,6 +374,9 @@ def kibana_export_rules(  # noqa: PLR0912, PLR0913, PLR0915
                     save_path, {"creation_date": local_creation_date, "updated_date": local_updated_date}
                 )
             )
+            if strip_dates or RULES_CONFIG.strip_dates:
+                params["creation_date"] = None
+                params["updated_date"] = None
             contents = TOMLRuleContents.from_rule_resource(**params)  # type: ignore[reportArgumentType]
             rule = TOMLRule(contents=contents, path=save_path)
         except Exception as e:
@@ -443,7 +446,7 @@ def kibana_export_rules(  # noqa: PLR0912, PLR0913, PLR0915
     saved: list[TOMLRule] = []
     for rule in exported:
         try:
-            rule.save_toml(strip_dates=strip_dates or RULES_CONFIG.strip_dates)
+            rule.save_toml()
         except Exception as e:
             if skip_errors:
                 print(f"- skipping {rule.contents.data.name} - {type(e).__name__}")

--- a/detection_rules/main.py
+++ b/detection_rules/main.py
@@ -87,7 +87,7 @@ def root(ctx: click.Context, debug: bool) -> None:
 def create_rule(path: Path, config: Path, required_only: bool, rule_type: str):  # noqa: ANN201
     """Create a detection rule."""
     contents: dict[str, Any] = load_rule_contents(config, single_only=True)[0] if config else {}
-    return rule_prompt(path, rule_type=rule_type, required_only=required_only, save=True, **contents)
+    return rule_prompt(path, rule_type=rule_type, required_only=required_only, save=True, strip_dates=False, **contents)
 
 
 @root.command("generate-rules-index")
@@ -155,6 +155,7 @@ def generate_rules_index(
 @click.option("--skip-errors", "-ske", is_flag=True, help="Skip rule import errors")
 @click.option("--default-author", "-da", type=str, required=False, help="Default author for rules missing one")
 @click.option("--strip-none-values", "-snv", is_flag=True, help="Strip None values from the rule")
+@click.option("--strip-dates", "-sd", is_flag=True, help="Strip creation and updated date fields from imported rules")
 @click.option("--local-creation-date", "-lc", is_flag=True, help="Preserve the local creation date of the rule")
 @click.option("--local-updated-date", "-lu", is_flag=True, help="Preserve the local updated date of the rule")
 def import_rules_into_repo(  # noqa: PLR0912, PLR0913, PLR0915
@@ -169,6 +170,7 @@ def import_rules_into_repo(  # noqa: PLR0912, PLR0913, PLR0915
     skip_errors: bool,
     default_author: str,
     strip_none_values: bool,
+    strip_dates: bool,
     local_creation_date: bool,
     local_updated_date: bool,
 ) -> None:
@@ -230,6 +232,10 @@ def import_rules_into_repo(  # noqa: PLR0912, PLR0913, PLR0915
             )
         )
 
+        if strip_dates:
+            contents.pop("creation_date", None)
+            contents.pop("updated_date", None)
+
         output = rule_prompt(
             rule_path,
             required_only=required_only,
@@ -238,6 +244,7 @@ def import_rules_into_repo(  # noqa: PLR0912, PLR0913, PLR0915
             additional_required=additional,
             skip_errors=skip_errors,
             strip_none_values=strip_none_values,
+            strip_dates=strip_dates,
             **contents,
         )
         # If output is not a TOMLRule

--- a/detection_rules/packaging.py
+++ b/detection_rules/packaging.py
@@ -131,7 +131,10 @@ class Package:
 
     def _package_kibana_index_file(self, save_dir: Path) -> None:
         """Convert and save index file with package."""
-        sorted_rules = sorted(self.rules, key=lambda k: (k.contents.metadata.creation_date, k.path.name))  # type: ignore[reportOptionalMemberAccess]
+        sorted_rules = sorted(
+            self.rules,
+            key=lambda k: (k.contents.metadata.creation_date or "", k.path.name),
+        )  # type: ignore[reportOptionalMemberAccess]
         comments = [
             "// Auto generated file from either:",
             "// - scripts/regen_prepackage_rules_index.sh",

--- a/detection_rules/rule.py
+++ b/detection_rules/rule.py
@@ -1585,12 +1585,17 @@ class TOMLRule:
                 return rule_path.relative_to(rules_dir)
         return None
 
-    def save_toml(self, strip_none_values: bool = True) -> None:
+    def save_toml(self, strip_none_values: bool = True, strip_dates: bool = False) -> None:
         if self.path is None:
             raise ValueError(f"Can't save rule {self.name} (self.id) without a path")
 
+        metadata = self.contents.metadata.to_dict()
+        if strip_dates:
+            metadata.pop("creation_date", None)
+            metadata.pop("updated_date", None)
+
         converted = {
-            "metadata": self.contents.metadata.to_dict(),
+            "metadata": metadata,
             "rule": self.contents.data.to_dict(strip_none_values=strip_none_values),
         }
         if self.contents.transform:

--- a/detection_rules/rule.py
+++ b/detection_rules/rule.py
@@ -108,8 +108,8 @@ class DictRule:
 class RuleMeta(MarshmallowDataclassMixin):
     """Data stored in a rule's [metadata] section of TOML."""
 
-    creation_date: definitions.Date
-    updated_date: definitions.Date
+    creation_date: definitions.Date | None = None
+    updated_date: definitions.Date | None = None
     deprecation_date: definitions.Date | None = None
 
     # Optional fields

--- a/docs-logs/optional-metadata-dates.md
+++ b/docs-logs/optional-metadata-dates.md
@@ -1,0 +1,5 @@
+# Optional Metadata Dates
+
+Validation of rule TOML files no longer fails if `creation_date` or `updated_date` fields are missing. These values may be stripped during export and should not be required on import.
+
+Implementation updated `RuleMeta` in `detection_rules/rule.py` to make these fields optional and adjusted sorting in `packaging.py` to handle missing dates. Test `test_updated_date_newer_than_creation` now skips rules without date metadata.

--- a/docs-logs/strip-dates.md
+++ b/docs-logs/strip-dates.md
@@ -1,0 +1,8 @@
+# Strip Dates Option
+
+A new `strip_dates` flag was added to the rule export workflow. When enabled via the
+`--strip-dates` command line option or the `strip_dates` field in `_config.yaml`,
+`creation_date` and `updated_date` are removed before writing the rule TOML.
+This helps avoid noisy diffs when exporting rules from Kibana and re-importing
+them across clusters.
+

--- a/docs-logs/strip-dates.md
+++ b/docs-logs/strip-dates.md
@@ -3,6 +3,11 @@
 A new `strip_dates` flag was added to the rule export workflow. When enabled via the
 `--strip-dates` command line option or the `strip_dates` field in `_config.yaml`,
 `creation_date` and `updated_date` are removed before writing the rule TOML.
+The metadata removal now occurs before the rule object is serialized, similar to
+the `strip_version` implementation. `from_rule_resource` accepts `None` for the
+date fields so they are completely omitted and `save_toml` no longer needs a
+`strip_dates` argument. The flag is also available on `import-rules-to-repo` to
+strip dates when creating local rules from exports.
 This helps avoid noisy diffs when exporting rules from Kibana and re-importing
 them across clusters.
 

--- a/tests/test_all_rules.py
+++ b/tests/test_all_rules.py
@@ -635,9 +635,11 @@ class TestRuleMetadata(BaseRuleTest):
         invalid = []
 
         for rule in self.all_rules:
-            created = rule.contents.metadata.creation_date.split("/")
-            updated = rule.contents.metadata.updated_date.split("/")
-            if updated < created:
+            created = rule.contents.metadata.creation_date
+            updated = rule.contents.metadata.updated_date
+            if not created or not updated:
+                continue
+            if updated.split("/") < created.split("/"):
                 invalid.append(rule)
 
         if invalid:


### PR DESCRIPTION
## Summary
- allow optional creation_date and updated_date in rule metadata
- handle missing metadata dates when packaging rules
- skip date comparison in tests if metadata dates are missing
- document the metadata date change

## Testing
- `python -m ruff check --exit-non-zero-on-fix`

------
https://chatgpt.com/codex/tasks/task_e_6874fa2237d483339b30e9d7b8e8b8d6