### PR TITLE
Fix strip-dates for exceptions and connectors

### DIFF
--- a/detection_rules/kbwrap.py
+++ b/detection_rules/kbwrap.py
@@ -421,6 +421,7 @@ def kibana_export_rules(  # noqa: PLR0912, PLR0913, PLR0915
             save_toml=False,
             skip_errors=skip_errors,
             verbose=False,
+            strip_dates=strip_dates,
         )
         for line in e_output:
             click.echo(line)
@@ -439,6 +440,7 @@ def kibana_export_rules(  # noqa: PLR0912, PLR0913, PLR0915
             save_toml=False,
             skip_errors=skip_errors,
             verbose=False,
+            strip_dates=strip_dates,
         )
         for line in ac_output:
             click.echo(line)

--- a/detection_rules/main.py
+++ b/detection_rules/main.py
@@ -279,6 +279,7 @@ def import_rules_into_repo(  # noqa: PLR0912, PLR0913, PLR0915
             save_toml=True,
             skip_errors=skip_errors,
             verbose=True,
+            strip_dates=strip_dates,
         )
         for line in e_output:
             click.echo(line)
@@ -293,6 +294,7 @@ def import_rules_into_repo(  # noqa: PLR0912, PLR0913, PLR0915
             save_toml=True,
             skip_errors=skip_errors,
             verbose=True,
+            strip_dates=strip_dates,
         )
         for line in ac_output:
             click.echo(line)

--- a/docs-logs/strip-dates-exceptions-connectors.md
+++ b/docs-logs/strip-dates-exceptions-connectors.md
@@ -1,0 +1,6 @@
+# Strip Dates for Exceptions and Action Connectors
+
+The `--strip-dates` option on `export-rules` and `import-rules-to-repo` now also
+removes `creation_date` and `updated_date` from exported exception lists and
+action connector files.  Their metadata dataclasses were updated to accept
+`None` values so that rules can be imported back without errors.


### PR DESCRIPTION
## Summary
- handle `--strip-dates` for exception lists and action connectors
- allow optional dates in metadata
- document strip-dates fix

## Testing
- `python -m ruff check --exit-non-zero-on-fix`
- `python -m detection_rules kibana --space $SPACE export-rules -d tmp/export_test -ed tmp/export_test/exceptions -acd tmp/export_test/actions -da SOC --export-exceptions --strip-version --strip-dates --export-action-connectors`

------
https://chatgpt.com/codex/tasks/task_e_6877aa4e56c8833387b3adbb6a9c8220