### PR TITLE
Fix import without exception list id

### DIFF
--- a/docs-logs/auto-generate-exception-id.md
+++ b/docs-logs/auto-generate-exception-id.md
@@ -1,0 +1,14 @@
+# Auto-generate Exception List IDs on Import
+
+When using `import-rules` to load rule TOML files that have `id` fields stripped
+from their `exceptions_list` blocks, Kibana rejected the request with an error
+similar to:
+
+```
+(unknown id): (400) exceptions_list.0.id: Required
+```
+
+The import workflow now assigns a random UUID to each exception list entry that
+lacks an `id` before sending the payload to Kibana. This ensures rules without
+IDs can be imported successfully while keeping exported files clean when using
+`--strip-exception-list-id`.

--- a/lib/kibana/kibana/resources.py
+++ b/lib/kibana/kibana/resources.py
@@ -5,6 +5,7 @@
 
 import datetime
 from typing import List, Optional, Type
+from uuid import uuid4
 
 import json
 
@@ -241,6 +242,11 @@ class RuleResource(BaseResource):
             overwrite_exceptions=stringify_bool(overwrite_exceptions),
             overwrite_action_connectors=stringify_bool(overwrite_action_connectors),
         )
+        # add missing ids for exceptions_list entries to satisfy the Kibana API
+        for rule in rules:
+            for exc in rule.get("exceptions_list", []):
+                exc.setdefault("id", str(uuid4()))
+
         rule_ids = [r['rule_id'] for r in rules]
         flattened_exceptions = [e for sublist in exceptions for e in sublist]
         flattened_actions_connectors = [a for sublist in action_connectors for a in sublist]


### PR DESCRIPTION
## Summary
- generate uuid for missing exception list id when importing rules to Kibana
- document automatic id generation during import

## Testing
- `python -m ruff check --exit-non-zero-on-fix`
- `pytest -q`
- `pip install --upgrade --force-reinstall --no-deps lib/kibana`
- `python -m detection_rules kibana search-alerts`
- `python -m detection_rules kibana --space test-7621 import-rules -d /tmp/test-rules --overwrite --overwrite-action-connectors --overwrite-exceptions`

------
https://chatgpt.com/codex/tasks/task_e_687e32b6933c8333b5fe7dfc13c0bfc4