### PR TITLE
feat: add default author config

### DIFF
--- a/detection_rules/config.py
+++ b/detection_rules/config.py
@@ -212,6 +212,7 @@ class RulesConfig:
     strip_version: bool = False
     strip_dates: bool = False
     strip_exception_list_id: bool = False
+    default_author: str | None = None
 
     def __post_init__(self) -> None:
         """Perform post validation on packages.yaml file."""
@@ -339,6 +340,9 @@ def parse_rules_config(path: Path | None = None) -> RulesConfig:  # noqa: PLR091
 
     # strip_exception_list_id
     contents["strip_exception_list_id"] = loaded.get("strip_exception_list_id", False)
+
+    # default_author
+    contents["default_author"] = loaded.get("default_author")
 
     # return the config
     try:

--- a/detection_rules/etc/_config.yaml
+++ b/detection_rules/etc/_config.yaml
@@ -86,3 +86,6 @@ normalize_kql_keywords: False
 # strip_dates: True
 # Strip id fields from rule exceptions list when exporting rules
 # strip_exception_list_id: True
+
+# Set a default author for rules missing one during export or import
+# default_author: SOC

--- a/detection_rules/kbwrap.py
+++ b/detection_rules/kbwrap.py
@@ -282,6 +282,7 @@ def kibana_export_rules(  # noqa: PLR0912, PLR0913, PLR0915
     strip_version = strip_version or RULES_CONFIG.strip_version
     strip_dates = strip_dates or RULES_CONFIG.strip_dates
     strip_exception_list_id = strip_exception_list_id or RULES_CONFIG.strip_exception_list_id
+    default_author = default_author or RULES_CONFIG.default_author
     kibana_include_details = export_exceptions or export_action_connectors
 
     # Only allow one of rule_id or rule_name

--- a/detection_rules/main.py
+++ b/detection_rules/main.py
@@ -177,6 +177,8 @@ def import_rules_into_repo(  # noqa: PLR0912, PLR0913, PLR0915
     local_updated_date: bool,
 ) -> None:
     """Import rules from json, toml, or yaml files containing Kibana exported rule(s)."""
+    default_author = default_author or RULES_CONFIG.default_author
+
     errors: list[str] = []
 
     rule_files: list[Path] = []

--- a/docs-dev/custom-rules-management.md
+++ b/docs-dev/custom-rules-management.md
@@ -79,6 +79,8 @@ Some notes:
 * To on bulk disable elastic validation for optional fields, use the following line `bypass_optional_elastic_validation: True`.
 * To omit version fields when exporting rules, set `strip_version: True` or use the `--strip-version` flag. This only strips the
   `version` and `revision` fields from exported rule TOML files and does not impact the version lock strategy.
+* To supply a default author for rules that lack one when importing or exporting, set
+  `default_author: <name>` or use the `--default-author`/`-da` flag.
 
 
 When using the repo, set the environment variable `CUSTOM_RULES_DIR=<directory-with-_config.yaml>`

--- a/docs-logs/default-author-config.md
+++ b/docs-logs/default-author-config.md
@@ -1,0 +1,8 @@
+# Default Author Config
+
+The `import-rules-to-repo` and `kibana export-rules` commands now honor a
+`default_author` field in `_config.yaml`. This provides the same behavior as the
+`--default-author`/`-da` flag, allowing a default author to be supplied without
+specifying the flag on every invocation. The configuration is loaded into
+`RULES_CONFIG` and used whenever a rule lacks an `author` value.
+


### PR DESCRIPTION
## Summary
- add `default_author` config field to use in place of `--default-author`
- default to config value in import and export rule commands
- document new option in custom rules guide and docs logs

## Testing
- `python -m ruff check --exit-non-zero-on-fix`
- `python -m detection_rules kibana search-alerts`


------
https://chatgpt.com/codex/tasks/task_e_689090beb2a48333b3a111ba2411794c