### PR TITLE
Support importing referenced value lists

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -53,7 +53,7 @@ curl -X DELETE "$DR_KIBANA_URL/api/spaces/space/$SPACE" \
 # test rule import
 export CUSTOM_RULES_DIR=./rules-test
 python -m detection_rules import-rules --space $SPACE -d $CUSTOM_RULES_DIR/rules \
-    --overwrite --overwrite-action-connectors --overwrite-exceptions
+    --overwrite --overwrite-action-connectors --overwrite-exceptions --overwrite-value-lists
 
 # test rule export
 python -m detection_rules export-rules --space $SPACE -d $CUSTOM_RULES_DIR/rules \

--- a/CLI.md
+++ b/CLI.md
@@ -263,6 +263,7 @@ Options:
   -e, --overwrite-exceptions      Overwrite exceptions in existing rules
   -ac, --overwrite-action-connectors
                                   Overwrite action connectors in existing rules
+  -vl, --overwrite-value-lists    Overwrite value lists referenced in exceptions
   -h, --help                      Show this message and exit.
 ```
 

--- a/detection_rules/kbwrap.py
+++ b/detection_rules/kbwrap.py
@@ -105,13 +105,20 @@ def upload_rule(ctx: click.Context, rules: RuleCollection, replace_id: bool) -> 
     is_flag=True,
     help="Overwrite action connectors in existing rules",
 )
+@click.option(
+    "--overwrite-value-lists",
+    "-vl",
+    is_flag=True,
+    help="Overwrite value lists referenced in exceptions",
+)
 @click.pass_context
-def kibana_import_rules(  # noqa: PLR0915
+def kibana_import_rules(  # noqa: PLR0912, PLR0913, PLR0915
     ctx: click.Context,
     rules: RuleCollection,
     overwrite: bool = False,
     overwrite_exceptions: bool = False,
     overwrite_action_connectors: bool = False,
+    overwrite_value_lists: bool = False,
 ) -> tuple[dict[str, Any], list[RuleResource]]:
     """Import custom rules into Kibana."""
 
@@ -185,16 +192,54 @@ def kibana_import_rules(  # noqa: PLR0915
     rule_ids = {rule["rule_id"] for rule in rule_dicts}
     with kibana:
         cl = GenericCollection.default()
-        exception_dicts = [
-            d.contents.to_api_format()
-            for d in cl.items
-            if isinstance(d.contents, TOMLExceptionContents) and _matches_rule_ids(d, rule_ids)
-        ]
-        action_connectors_dicts = [
-            d.contents.to_api_format()
-            for d in cl.items
-            if isinstance(d.contents, TOMLActionConnectorContents) and _matches_rule_ids(d, rule_ids)
-        ]
+        exception_dicts: list[list[dict[str, Any]]] = []
+        action_connectors_dicts: list[list[dict[str, Any]]] = []
+        value_list_map: dict[str, str] = {}
+
+        def _collect_list_ids(entries: list[dict[str, Any]]) -> None:
+            for entry in entries:
+                if entry.get("type") == "list" and entry.get("list"):
+                    value_list_map[entry["list"]["id"]] = entry["list"].get("type", "keyword")
+                elif entry.get("type") == "nested":
+                    _collect_list_ids(entry.get("entries", []))
+
+        for d in cl.items:
+            if isinstance(d.contents, TOMLExceptionContents) and _matches_rule_ids(d, rule_ids):
+                edicts = d.contents.to_api_format()
+                exception_dicts.append(edicts)
+                for item in edicts:
+                    _collect_list_ids(item.get("entries", []))
+            elif isinstance(d.contents, TOMLActionConnectorContents) and _matches_rule_ids(d, rule_ids):
+                action_connectors_dicts.append(d.contents.to_api_format())
+
+        imported_value_lists: list[str] = []
+        skipped_value_lists: list[str] = []
+        missing_value_lists: list[str] = []
+        value_list_dir = RULES_CONFIG.value_list_dir
+        if value_list_map:
+            # the value list APIs expect an index to exist, so ensure it's created once
+            ValueListResource.create_index()
+        for list_id, list_type in value_list_map.items():
+            file_path = value_list_dir / list_id if value_list_dir else None
+            if not file_path or not file_path.exists():
+                missing_value_lists.append(list_id)
+                continue
+            text = file_path.read_text()
+            existing = ValueListResource.get(list_id)
+            if existing and not overwrite_value_lists:
+                # skip existing lists unless --overwrite-value-lists is provided
+                skipped_value_lists.append(list_id)
+                continue
+            if existing and overwrite_value_lists:
+                # deleting avoids duplicate items when re-importing
+                ValueListResource.delete(list_id)
+            if not existing or overwrite_value_lists:
+                # /items/_import only uploads items and does not create the list itself
+                ValueListResource.create(list_id, list_type)
+            # now populate the value list with its newline-delimited contents
+            ValueListResource.import_list_items(list_id, text, list_type)
+            imported_value_lists.append(list_id)
+
         response, successful_rule_ids, results = RuleResource.import_rules(  # type: ignore[reportUnknownMemberType]
             rule_dicts,
             exception_dicts,
@@ -213,6 +258,18 @@ def kibana_import_rules(  # noqa: PLR0915
     else:
         _process_imported_items(exception_dicts, "exception list(s)", "list_id")
         _process_imported_items(action_connectors_dicts, "action connector(s)", "id")
+        if imported_value_lists:
+            click.echo(f"{len(imported_value_lists)} value list(s) successfully imported")
+            ids_str = "\n - ".join(imported_value_lists)
+            click.echo(f" - {ids_str}")
+        if skipped_value_lists:
+            click.echo("Value lists already exist and were not overwritten:")
+            ids_str = "\n - ".join(skipped_value_lists)
+            click.echo(f" - {ids_str}")
+        if missing_value_lists:
+            click.echo("Value list files not found:")
+            ids_str = "\n - ".join(missing_value_lists)
+            click.echo(f" - {ids_str}")
 
     return response, results  # type: ignore[reportUnknownVariableType]
 

--- a/docs-logs/2025-08-duplicate-import-investigation.md
+++ b/docs-logs/2025-08-duplicate-import-investigation.md
@@ -52,6 +52,7 @@ Options:
   -o, --overwrite                 Overwrite existing rules
   -e, --overwrite-exceptions      Overwrite exceptions in existing rules
   -ac, --overwrite-action-connectors  Overwrite action connectors in existing rules
+  -vl, --overwrite-value-lists    Overwrite value lists referenced in exceptions
 ```
 
 An example from the same documentation demonstrates Kibana returning a `409` conflict when the `rule_id` already exists:

--- a/docs-logs/import-value-lists.md
+++ b/docs-logs/import-value-lists.md
@@ -1,0 +1,9 @@
+Feature: Import value lists with rules and exceptions.
+
+Added the ability for the `kibana import-rules` command to automatically import value lists referenced by exception lists. The command now accepts a `--overwrite-value-lists` flag and reads list files from the configured `value_list_dir`.
+
+Implementation:
+- Extended `ValueListResource` with methods to retrieve, delete, and import list items using `/api/lists/items/_import`.
+- Updated `kibana import-rules` to load value list files prior to rule import, upload them when referenced by exceptions, and report skipped or missing lists.
+- Documented the new `--overwrite-value-lists` flag across CLI docs and example workflows.
+- Corrected value list existence checks to ignore 404 responses so lists are imported on fresh spaces without `--overwrite-value-lists`.

--- a/lib/kibana/kibana/resources.py
+++ b/lib/kibana/kibana/resources.py
@@ -285,6 +285,65 @@ class ValueListResource(BaseResource):
     BASE_URI = "/api/lists"
 
     @classmethod
+    def get(cls, list_id: str) -> dict | None:
+        """Retrieve a value list by ID.
+
+        The API returns a JSON body with ``status_code: 404`` when the list is
+        missing, even though ``error=False`` suppresses HTTP errors. In that
+        case return ``None`` so callers can treat the list as nonexistent.
+        """
+        response = Kibana.current().get(cls.BASE_URI, params={"id": list_id}, error=False)
+        if not response:
+            return None
+        status_code = response.get("status_code") or response.get("statusCode")
+        if status_code == 404:
+            return None
+        return response
+
+    @classmethod
+    def delete(cls, list_id: str) -> None:
+        """Delete a value list by ID."""
+        Kibana.current().delete(cls.BASE_URI, params={"id": list_id}, error=False)
+
+    @classmethod
+    def create_index(cls) -> None:
+        """Ensure the value list index exists."""
+        Kibana.current().post(f"{cls.BASE_URI}/index", error=False)
+
+    @classmethod
+    def create(cls, list_id: str, list_type: str, name: str | None = None, description: str | None = None) -> dict:
+        """Create a value list."""
+        payload = {
+            "id": list_id,
+            "type": list_type,
+            "name": name or list_id,
+            "description": description or name or list_id,
+        }
+        return Kibana.current().post(cls.BASE_URI, data=payload)
+
+    @classmethod
+    def import_list_items(cls, list_id: str, text: str, list_type: str) -> dict:
+        """Import newline-delimited items into an existing value list.
+
+        The `/api/lists/items/_import` endpoint only adds items to a list that
+        already exists and will not implicitly create the list. Callers must
+        ensure the value list (and its backing index) are created before
+        invoking this helper.
+        """
+        boundary = "----ElasticBoundary"
+        body = (
+            f"--{boundary}\r\n"
+            f"Content-Disposition: form-data; name=\"file\"; filename=\"{list_id}\"\r\n"
+            "Content-Type: text/plain\r\n\r\n"
+            f"{text}\r\n--{boundary}--\r\n"
+        ).encode("utf-8")
+        headers = {"content-type": f"multipart/form-data; boundary={boundary}"}
+        params = {"list_id": list_id, "type": list_type}
+        return Kibana.current().post(
+            f"{cls.BASE_URI}/items/_import", params=params, raw_data=body, headers=headers
+        )
+
+    @classmethod
     def export_list_items(cls, list_id: str) -> str:
         """Export the contents of a value list as newline-delimited text."""
         response = Kibana.current().post(


### PR DESCRIPTION
## Summary
- allow `kibana import-rules` to upload value lists referenced in exceptions
- add `--overwrite-value-lists` flag to control replacing existing lists
- document value list import workflow and flag usage
- clarify value list import flow with inline documentation
- correctly detect missing value lists so they import even without `--overwrite-value-lists`

## Testing
- `python -m ruff check --exit-non-zero-on-fix`
- `python -m detection_rules kibana search-alerts`
- `python -m detection_rules kibana --space $SPACE import-rules -d $CUSTOM_RULES_DIR/rules --overwrite --overwrite-action-connectors --overwrite-exceptions`
- `python -m detection_rules kibana --space $SPACE import-rules -d $CUSTOM_RULES_DIR/rules --overwrite --overwrite-action-connectors --overwrite-exceptions --overwrite-value-lists`


------
https://chatgpt.com/codex/tasks/task_e_68a5b9d73eb0833396bbb3c85207f7eb