### PR TITLE
feat: add rule-name filter to import-rules

### DIFF
--- a/CLI.md
+++ b/CLI.md
@@ -232,7 +232,8 @@ Running the following command will print out a table showing any alerts that hav
 ### Using `kibana import-rules`
 
 To directly load Toml formatted rule files into Kibana, one can use the `kibana import-rules` command as shown below. If the
-`-d/--directory` option is omitted, the first path listed in the `rule_dirs` array of `_config.yaml` is used.
+`-d/--directory` option is omitted, the first path listed in the `rule_dirs` array of `_config.yaml` is used. Use `--rule-name`
+(`-rn`) to import only rules whose names match a pattern; wildcards are supported and the flag may be specified multiple times.
 
 ```
 python -m detection_rules kibana import-rules -h
@@ -259,6 +260,7 @@ Options:
   -f, --rule-file FILE
   -d, --directory DIRECTORY       Recursively load rules from a directory
   -id, --rule-id TEXT
+  -rn, --rule-name TEXT           Optional rule name to restrict import to (case-insensitive, supports wildcards). May be specified multiple times.
   -nt, --no-tactic-filename       Allow rule filenames without tactic prefix. Use this if rules have been exported with this flag.
   -o, --overwrite                 Overwrite existing rules
   -e, --overwrite-exceptions      Overwrite exceptions in existing rules

--- a/detection_rules/kbwrap.py
+++ b/detection_rules/kbwrap.py
@@ -111,16 +111,34 @@ def upload_rule(ctx: click.Context, rules: RuleCollection, replace_id: bool) -> 
     is_flag=True,
     help="Overwrite value lists referenced in exceptions",
 )
+@click.option(
+    "--rule-name",
+    "-rn",
+    multiple=True,
+    required=False,
+    help=(
+        "Optional rule name to restrict import to (case-insensitive, supports wildcards). "
+        "May be specified multiple times."
+    ),
+)
 @click.pass_context
 def kibana_import_rules(  # noqa: PLR0912, PLR0913, PLR0915
     ctx: click.Context,
     rules: RuleCollection,
+    rule_name: list[str] | None = None,
     overwrite: bool = False,
     overwrite_exceptions: bool = False,
     overwrite_action_connectors: bool = False,
     overwrite_value_lists: bool = False,
 ) -> tuple[dict[str, Any], list[RuleResource]]:
     """Import custom rules into Kibana."""
+
+    if rule_name:
+        if ctx.params.get("rule_id"):
+            raise click.UsageError("Cannot use --rule-id and --rule-name together. Please choose one.")
+        rules = rules.filter_by_name(rule_name)
+        if len(rules) == 0:
+            raise click.UsageError("No rules match the provided --rule-name pattern(s).")
 
     def _handle_response_errors(response: dict[str, Any]) -> None:
         """Handle errors from the import response."""

--- a/detection_rules/rule_loader.py
+++ b/detection_rules/rule_loader.py
@@ -5,9 +5,11 @@
 
 """Load rule metadata transform between rule and api formats."""
 
+import fnmatch
 import json
+import re
 from collections import OrderedDict
-from collections.abc import Callable, Iterable, Iterator
+from collections.abc import Callable, Iterable, Iterator, Sequence
 from dataclasses import dataclass, field
 from multiprocessing.pool import ThreadPool
 from pathlib import Path
@@ -400,6 +402,15 @@ class RuleCollection(BaseCollection[TOMLRule]):
             filtered_collection.add_rule(rule)
 
         return filtered_collection
+
+    def filter_by_name(self, patterns: Sequence[str]) -> "RuleCollection":
+        """Retrieve rules whose name matches any of the glob ``patterns``.
+
+        Matching is case-insensitive and supports standard shell wildcards
+        (``*`` and ``?``)."""
+
+        compiled = [re.compile(fnmatch.translate(pat), re.IGNORECASE) for pat in patterns]
+        return self.filter(lambda r: any(rx.match(r.contents.data.name) for rx in compiled))
 
     @staticmethod
     def deserialize_toml_string(contents: bytes | str) -> dict[str, Any]:

--- a/docs-logs/import-rule-name-flag.md
+++ b/docs-logs/import-rule-name-flag.md
@@ -1,0 +1,9 @@
+# Import rule name flag for `kibana import-rules`
+
+## Summary
+Adds a `--rule-name` (`-rn`) option to the `kibana import-rules` command to import only rules whose `rule.name` matches a given pattern. Patterns are case-insensitive and support shell wildcards like `*`. The flag can be repeated to match multiple patterns.
+
+## Implementation details
+- Introduced a `filter_by_name` method on `RuleCollection` that compiles glob patterns to regular expressions for efficient matching.
+- Updated `kibana import-rules` to accept the new option, reject combinations with `--rule-id`, and filter the loaded rule files using the new helper.
+- Documented the option in `CLI.md` and added unit tests verifying name filtering.

--- a/tests/test_rule_name_filter.py
+++ b/tests/test_rule_name_filter.py
@@ -1,0 +1,19 @@
+from pathlib import Path
+
+from detection_rules.rule_loader import RuleCollection
+
+
+def test_filter_by_name_patterns() -> None:
+    rc = RuleCollection()
+    rc.load_files(
+        [
+            Path("rules-test/rules/test01_windows_event_log_cleared.toml"),
+            Path("rules-test/rules/test02_windows_event_log_modified.toml"),
+        ]
+    )
+    filtered = rc.filter_by_name(["Test01*Cleared"])
+    assert len(filtered) == 1
+    assert next(iter(filtered)).contents.data.name == "Test01 - Windows Event Log Cleared"
+
+    filtered_multi = rc.filter_by_name(["*Cleared", "*Modified"])
+    assert len(filtered_multi) == 2


### PR DESCRIPTION
## Summary
- add `--rule-name`/`-rn` to `kibana import-rules` for case-insensitive wildcard filtering
- support rule name glob matching via new `RuleCollection.filter_by_name`
- document new flag and add tests

## Testing
- `python -m ruff check --exit-non-zero-on-fix`
- `pytest tests` *(fails: fatal: ambiguous argument 'origin/main': unknown revision or path not in the working tree)*
- `pytest tests/test_rule_name_filter.py`
- `python -m detection_rules kibana search-alerts`
- `python -m detection_rules kibana --space test-4821 import-rules -d ./rules-test/rules --overwrite --overwrite-action-connectors --overwrite-exceptions --overwrite-value-lists --rule-name "Test01*Cleared"`


------
https://chatgpt.com/codex/tasks/task_e_68a5d27848e48333b12d8a89dacfbf1e