### PR TITLE
feat: import rules by name

### DIFF
--- a/CLI.md
+++ b/CLI.md
@@ -232,7 +232,8 @@ Running the following command will print out a table showing any alerts that hav
 ### Using `kibana import-rules`
 
 To directly load Toml formatted rule files into Kibana, one can use the `kibana import-rules` command as shown below. If the
-`-d/--directory` option is omitted, the first path listed in the `rule_dirs` array of `_config.yaml` is used.
+`-d/--directory` option is omitted, the first path listed in the `rule_dirs` array of `_config.yaml` is used. Rules can also be
+selected by name via `--rule-name`, which accepts wildcards and may be specified multiple times.
 
 ```
 python -m detection_rules kibana import-rules -h
@@ -259,6 +260,8 @@ Options:
   -f, --rule-file FILE
   -d, --directory DIRECTORY       Recursively load rules from a directory
   -id, --rule-id TEXT
+  -rn, --rule-name TEXT           Optional Rule name to restrict import to (case-insensitive,
+                                  supports wildcards). May be specified multiple times.
   -nt, --no-tactic-filename       Allow rule filenames without tactic prefix. Use this if rules have been exported with this flag.
   -o, --overwrite                 Overwrite existing rules
   -e, --overwrite-exceptions      Overwrite exceptions in existing rules
@@ -279,6 +282,12 @@ python -m detection_rules kibana import-rules -f test-export-rules/credential_ac
 
 1 rule(s) successfully imported
  - 50887ba8-aaaa-bbbb-a038-f661ea17fbcd
+```
+
+Importing by rule name with a wildcard pattern:
+
+```
+python -m detection_rules kibana import-rules -d test-export-rules --rule-name "credential_access*NEW_RULE"
 ```
 
 <details>

--- a/docs-logs/import-rules-rule-name-flag.md
+++ b/docs-logs/import-rules-rule-name-flag.md
@@ -1,0 +1,12 @@
+# Import rules by rule name
+
+## Summary
+- Added `--rule-name` option to `kibana import-rules` allowing selection of rules by `rule.name` instead of filename.
+- Supports multiple names and Unix-shell style wildcards in a case-insensitive manner.
+
+## Implementation Details
+- Extended `multi_collection` helper to accept a new `--rule-name/-rn` option and to filter loaded rules using compiled
+  `fnmatch` patterns.
+- Added validation to prevent using `--rule-id` and `--rule-name` together and updated default directory resolution to
+  include the new flag.
+- Updated CLI documentation and help text to describe the new option.

--- a/tests/test_multi_collection_rule_name.py
+++ b/tests/test_multi_collection_rule_name.py
@@ -1,0 +1,83 @@
+import click
+from click.testing import CliRunner
+
+from detection_rules.cli_utils import multi_collection
+from detection_rules.rule_loader import RuleCollection
+
+
+@click.command()
+@multi_collection
+def _cmd(rules: RuleCollection) -> None:
+    click.echo("|".join(sorted(r.name for r in rules)))
+
+
+def test_rule_name_exact():
+    runner = CliRunner()
+    result = runner.invoke(
+        _cmd,
+        [
+            "-d",
+            "rules-test/rules",
+            "--rule-name",
+            "Test01 - Windows Event Log Cleared",
+            "--no-tactic-filename",
+        ],
+    )
+    assert result.exit_code == 0
+    assert result.output.strip() == "Test01 - Windows Event Log Cleared"
+
+
+def test_rule_name_wildcard():
+    runner = CliRunner()
+    result = runner.invoke(
+        _cmd,
+        [
+            "-d",
+            "rules-test/rules",
+            "--rule-name",
+            "test01*cleared",
+            "--no-tactic-filename",
+        ],
+    )
+    assert result.exit_code == 0
+    assert result.output.strip() == "Test01 - Windows Event Log Cleared"
+
+
+def test_multiple_rule_name():
+    runner = CliRunner()
+    result = runner.invoke(
+        _cmd,
+        [
+            "-d",
+            "rules-test/rules",
+            "--rule-name",
+            "Test01*",
+            "--rule-name",
+            "Test02*",
+            "--no-tactic-filename",
+        ],
+    )
+    assert result.exit_code == 0
+    names = result.output.strip().split("|")
+    assert sorted(names) == [
+        "Test01 - Windows Event Log Cleared",
+        "Test02 - Windows Event Log Modified",
+    ]
+
+
+def test_rule_name_conflict_with_id():
+    runner = CliRunner()
+    result = runner.invoke(
+        _cmd,
+        [
+            "-d",
+            "rules-test/rules",
+            "--rule-name",
+            "Test01*",
+            "--rule-id",
+            "de7a3fda-0ef5-e8a0-ad54-f8e1fd2d1dbf",
+            "--no-tactic-filename",
+        ],
+    )
+    assert result.exit_code != 0
+    assert "Cannot use --rule-id and --rule-name together" in result.output


### PR DESCRIPTION
## Summary
- allow selecting rules by name via `--rule-name/-rn` with wildcard support
- document rule-name import option
- add tests for rule-name filtering

## Testing
- `python -m ruff check tests/test_multi_collection_rule_name.py detection_rules/cli_utils.py --exit-non-zero-on-fix`
- `pytest tests/test_multi_collection_rule_name.py`
- `python -m detection_rules kibana search-alerts`
- `python -m detection_rules kibana --space $SPACE import-rules --rule-name "Test01*Cleared" --no-tactic-filename --overwrite --overwrite-exceptions --overwrite-action-connectors --overwrite-value-lists`


------
https://chatgpt.com/codex/tasks/task_e_68a5d27848e48333b12d8a89dacfbf1e