### PR TITLE
feat: support value list overwrite

### DIFF
--- a/detection_rules/kbwrap.py
+++ b/detection_rules/kbwrap.py
@@ -294,9 +294,11 @@ def kibana_import_rules(  # noqa: PLR0912, PLR0913, PLR0915
                 skipped_value_lists.append(list_id)
                 continue
             if existing and overwrite_value_lists:
-                # deleting avoids duplicate items when re-importing
-                ValueListResource.delete(list_id)
-            if not existing or overwrite_value_lists:
+                # Deleting the list itself fails when it is referenced by
+                # active exception items. Instead clear its contents and
+                # re-import to avoid duplicate entries.
+                ValueListResource.delete_list_items(list_id)
+            else:
                 # /items/_import only uploads items and does not create the list itself
                 ValueListResource.create(list_id, list_type)
             # now populate the value list with its newline-delimited contents

--- a/docs-logs/value-list-overwrite.md
+++ b/docs-logs/value-list-overwrite.md
@@ -1,0 +1,14 @@
+Bugfix: Overwrite existing value lists without deleting the list.
+
+Importing rules with the `--overwrite-value-lists` flag previously tried to delete
+value lists before re-importing their items. Kibana rejects deletion when lists
+are referenced by exception items, which left old entries in place and caused
+duplicates.
+
+Implementation:
+- Added `find_list_items`, `delete_list_item`, and `delete_list_items` helpers to
+  `ValueListResource` using the `/api/lists/items/_find` and `/api/lists/items`
+  APIs.
+- Updated `kibana import-rules` to clear list items when overwriting instead of
+  deleting the list container.
+- Documented the reasoning in code comments.


### PR DESCRIPTION
## Summary
- remove existing value list items when overwrite flag is used
- add Kibana helpers to find and delete value list items
- document value list overwrite behaviour

## Testing
- `python -m ruff check --exit-non-zero-on-fix detection_rules lib/kibana`
- `pytest tests/test_utils.py`
- `python -m detection_rules kibana search-alerts`
- `python -m detection_rules kibana --space $SPACE import-rules -d $CUSTOM_RULES_DIR/rules --overwrite --overwrite-action-connectors --overwrite-exceptions --overwrite-timeline-templates`
- `python -m detection_rules kibana --space $SPACE import-rules -d $CUSTOM_RULES_DIR/rules --overwrite --overwrite-action-connectors --overwrite-exceptions --overwrite-value-lists --overwrite-timeline-templates`
- `python - <<'PY'
import os
from kibana.connector import Kibana
from kibana.resources import ValueListResource
with Kibana(kibana_url=os.environ['DR_KIBANA_URL'], api_key=os.environ['DR_API_KEY'], space=os.environ['SPACE']):
    text = ValueListResource.export_list_items('test.txt')
    print(text)
    print('count:', len([l for l in text.splitlines() if l]))
PY`

------
https://chatgpt.com/codex/tasks/task_e_68af18b6f5348333be3aa8cdd6228ae8