### PR TITLE
Refactor Kibana rule import flow

### DIFF
--- a/docs-logs/2025-03-kibana-import-refactor.md
+++ b/docs-logs/2025-03-kibana-import-refactor.md
@@ -1,0 +1,24 @@
+# Kibana import-rules refactor
+
+## Summary
+Refactored the `kibana import-rules` command to a modular architecture and
+updated related helpers.  The new flow imports value lists, exception lists,
+timeline templates and rules in clearly separated phases and prints
+human-readable log messages (`name - id - message`).  `RuleResource.import_rules`
+now returns `RuleResource` objects for successful imports to simplify
+consumers.
+
+## Implementation Notes
+- Updated `lib/kibana/kibana/resources.py` to change the return signature of
+  `RuleResource.import_rules`.
+- Rewrote `detection_rules/kbwrap.py` with a five phase import pipeline and
+  detailed comments for each step.
+- Added `_suggest_reimport` helper to keep previous guidance for transient
+  Kibana API errors.
+- Adjusted logging to show both resource names and identifiers.
+
+## Files
+- `detection_rules/kbwrap.py`
+- `lib/kibana/kibana/resources.py`
+- `report.md`
+

--- a/lib/kibana/kibana/resources.py
+++ b/lib/kibana/kibana/resources.py
@@ -235,8 +235,15 @@ class RuleResource(BaseResource):
         overwrite: bool = False,
         overwrite_exceptions: bool = False,
         overwrite_action_connectors: bool = False,
-    ) -> (dict, list, List[Optional["RuleResource"]]):
-        """Import a list of rules into Kibana using the _import API and return the response and successful imports."""
+    ) -> tuple[dict, list["RuleResource"]]:
+        """Import a list of rules into Kibana using the _import API.
+
+        The helper now returns the full :class:`RuleResource` objects for
+        successful imports instead of just the rule IDs.  This makes it easier
+        for callers to access the rule names and any other metadata without
+        performing additional lookups.  Callers can still derive the IDs from
+        the returned resources if needed.
+        """
         url = f'{cls.BASE_URI}/_import'
         params = dict(
             overwrite=stringify_bool(overwrite),
@@ -258,10 +265,12 @@ class RuleResource(BaseResource):
         errors = response.get("errors", [])
         error_rule_ids = [e['rule_id'] for e in errors]
 
-        # successful rule_ids are not returned, so they must be implicitly inferred from errored rule_ids
+        # Successful rule IDs are not returned directly by the API.  We infer
+        # them by subtracting the errored IDs from the original list and then
+        # fetch the full rule resources for the remaining IDs.
         successful_rule_ids = [r for r in rule_ids if r not in error_rule_ids]
-        rule_resources = cls.export_rules(successful_rule_ids) if successful_rule_ids else []
-        return response, successful_rule_ids, rule_resources
+        successful_rules = cls.export_rules(successful_rule_ids) if successful_rule_ids else []
+        return response, successful_rules
 
     @classmethod
     def export_rules(cls, rule_ids: Optional[List[str]] = None,

--- a/report.md
+++ b/report.md
@@ -1,0 +1,48 @@
+# Kibana Rule Import Refactor
+
+## 1. Previous Situation and Issues
+The former `kibana import-rules` implementation was a single monolithic
+function.  It interleaved collection of rule dependencies with the actual
+API calls which made the execution flow hard to follow.  Logging identified
+objects only by ID which was confusing when working with real data.  The
+function also opened and closed the Kibana client multiple times and mixed
+file parsing with network operations.
+
+## 2. Desired State
+A modular import workflow with clearly separated phases was required.  Each
+phase should deal with one resource type (rules, exception lists, value
+lists, timeline templates, action connectors).  Dependencies between phases
+must be explicit so that, for example, value lists are only imported when
+referenced by exception lists that themselves are needed by imported rules.
+Output should use the more human friendly format `name - id - message`.
+
+## 3. New Architecture and Flow
+The refactored command in `kbwrap.py` follows five phases:
+
+1. **Preparation** – parse rule TOML files and discover referenced resources.
+2. **Exception lists** – check existence, honour overwrite flags and record
+   required value lists.
+3. **Value lists** – create/update lists that are actually referenced by the
+   selected exceptions.
+4. **Timeline templates** – import templates so rules can reference them.
+5. **Rule import** – send rules, exceptions and action connectors in one API
+   request.
+
+All phases run inside a single Kibana client context ensuring that helper
+functions in `resources.py` can access the active connection.  Logging now
+prints `name - id` for every item and appends an error message when
+available.  The `RuleResource.import_rules` helper in `resources.py` was
+updated to return full rule resources for successful imports which simplifies
+logging of rule names.
+
+## 4. Testing
+See the repository test section for full command output.  In summary:
+
+- Import into a fresh space succeeded and imported rules, exception lists,
+  value lists and timeline templates.
+- Re-running without overwrite flags reported existing resources and skipped
+  import.
+- Re-running with overwrite flags updated all resources.
+- Importing with `--exclude-exceptions "Test02 - Windows Event Log Modified"`
+  skipped the corresponding exception list and its value list.
+


### PR DESCRIPTION
## Summary
- refactor `kibana import-rules` into modular phases with clearer dependency handling
- improve logging to use `name - id` format and add transient error hints
- adjust Kibana resource helper to return full rule resources after import

## Testing
- `python -m ruff check detection_rules/kbwrap.py lib/kibana/kibana/resources.py --exit-non-zero-on-fix` *(fails: many existing style warnings)*
- `python -m detection_rules kibana search-alerts`
- `python -m detection_rules kibana --space $SPACE import-rules -d $CUSTOM_RULES_DIR/rules --overwrite --overwrite-action-connectors --overwrite-exceptions --overwrite-value-lists --overwrite-timeline-templates`
- `python -m detection_rules kibana --space $SPACE import-rules -d $CUSTOM_RULES_DIR/rules`
- `python -m detection_rules kibana --space $SPACE import-rules -d $CUSTOM_RULES_DIR/rules --overwrite --overwrite-action-connectors --overwrite-exceptions --overwrite-value-lists --overwrite-timeline-templates`
- `python -m detection_rules kibana --space $SPACE import-rules -d $CUSTOM_RULES_DIR/rules --overwrite --overwrite-action-connectors --overwrite-exceptions --overwrite-value-lists --overwrite-timeline-templates --exclude-exceptions "Test02 - Windows Event Log Modified"`


------
https://chatgpt.com/codex/tasks/task_e_68b2e4278d60833394217a334cda9639