### PR TITLE
Refactor Kibana rule import flow and export logging

### DIFF
--- a/docs-logs/2025-03-kibana-export-refactor.md
+++ b/docs-logs/2025-03-kibana-export-refactor.md
@@ -1,0 +1,10 @@
+# Kibana Export Refactor
+
+## Summary
+- improve `kibana export-rules` logging using shared `ItemLog`
+- report saved and skipped items using `name - id` format
+
+## Implementation Details
+- added `ItemLog` helper and per-resource log collection in `detection_rules/kbwrap.py`
+- adjusted loops saving rules, exceptions, value lists, timeline templates and action connectors to capture successes and failures
+- final summary prints grouped lists for each resource type


### PR DESCRIPTION
## Summary
- refactor `kibana import-rules` into modular phases with clearer dependency handling
- improve export logging by collecting `ItemLog` entries and reporting saved/skipped items per resource
- document new export flow

## Testing
- `python -m ruff check detection_rules/kbwrap.py --exit-non-zero-on-fix` *(fails: PLR0913, PLR0912, PLR0915)*
- `python -m detection_rules kibana search-alerts`
- `python -m detection_rules kibana --space $SPACE import-rules -d $CUSTOM_RULES_DIR/rules --overwrite --overwrite-action-connectors --overwrite-exceptions --overwrite-value-lists --overwrite-timeline-templates`
- `python -m detection_rules kibana --space $SPACE export-rules -d $TMP1/rules -acd $TMP1/action_connectors -ed $TMP1/exceptions -vld $TMP1/value_lists -ttd $TMP1/timeline_templates -da SOC --export-action-connectors --export-exceptions --export-value-lists --export-timeline-templates --strip-version`
- `python -m detection_rules kibana --space $SPACE export-rules -d $TMP2/rules -acd $TMP2/action_connectors -ed $TMP2/exceptions -vld $TMP2/value_lists -ttd $TMP2/timeline_templates -da SOC --export-action-connectors --export-exceptions --export-value-lists --export-timeline-templates --strip-version --strip-dates --strip-exception-list-id`
- `python -m detection_rules kibana --space $SPACE export-rules -d $TMP3/rules -ed $TMP3/exceptions --export-exceptions --strip-version`


------
https://chatgpt.com/codex/tasks/task_e_68b2e4278d60833394217a334cda9639